### PR TITLE
Adding YESCDS to Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,8 @@ Suggests:
     glue,
     sessioninfo,
     knitr 
+Remotes: 
+    github::vjcitn/YESCDS
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 BiocType: Book

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description:
 	YESCDS is an R package with data and software tools for the exploration
 	of cancer data science.  This BiocBook formats the material and
 	addresses maintenance via github actions.
-Version: 0.98.2
+Version: 0.98.3
 Date: `r date()`
 Authors@R: 
     person(

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- badges: start -->
 📦 [Repo](https://github.com/vjcitn/YESCDSbook) [![rworkflows](https://img.shields.io/github/actions/workflow/status/vjcitn/YESCDSbook/rworkflows.yml?label=Package%20check)](https://github.com/vjcitn/YESCDSbook/actions/workflows/rworkflows.yml)   
-📖 [Book](https://vjcitn.github.io/YESCDSbook/devel) [![deployment](https://img.shields.io/github/actions/workflow/status/vjcitn/YESCDSbook/pages/pages-build-deployment?label=Book%20deployment)](https://github.com/vjcitn/YESCDSbook/actions/workflows/pages/pages-build-deployment)  
+📖 [Book](https://vjcitn.github.io/YESCDSbook/docs/devel) [![deployment](https://img.shields.io/github/actions/workflow/status/vjcitn/YESCDSbook/pages/pages-build-deployment?label=Book%20deployment)](https://github.com/vjcitn/YESCDSbook/actions/workflows/pages/pages-build-deployment)  
 🐳 [Docker](https://github.com/vjcitn/YESCDSbook/pkgs/container/YESCDSbook) [![biocbook](https://img.shields.io/github/actions/workflow/status/vjcitn/YESCDSbook/biocbook.yml?label=Docker%20image)](https://github.com/vjcitn/YESCDSbook/actions/workflows/biocbook.yml)  
 <!-- badges: end -->

--- a/inst/assets/_book.yml
+++ b/inst/assets/_book.yml
@@ -16,7 +16,7 @@ book:
           - text: Source Code
             url:  https://github.com/vjcitn/YESCDSbook/
           - text: Browse version `devel`
-            url:  https://vjcitn.github.io/YESCDSbook/devel/
+            url:  https://vjcitn.github.io/YESCDSbook/docs/devel/
     style: "docked"
     background: "light"
     collapse-level: 5


### PR DESCRIPTION
- `YESCDS` is only available from your Github repository, this has to be indicated in the DESCRIPTION. 
- For Github to host the book rendered in `gh-pages` branch, you'll have to manually go to your package Settings -> Pages tab (on the left navbar) and select the `gh-pages` branch for deployment. This will expose the root of your `gh-pages` online at https://vjcitn.github.io/YESCDSbook/docs/devel/ (once the book has been successfully rendered at least once). I have fixed the URL in the `README` and `_book.yml` files.